### PR TITLE
Adds support for getBoundingClientRect for upcoming offsetWidth deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = function(elements, options) {
   var baseline = options.baseline || 16;
   var paddingY = options.paddingY || 0;
   var doc = options.doc || document;
+  var bounding = typeof doc.createElementNS('http://www.w3.org/2000/svg', 'svg').getBoundingClientRect === 'function';
 
   for (var i = 0; i < elements.length; i++) {
 
@@ -15,8 +16,7 @@ module.exports = function(elements, options) {
     var content = elements[i].textContent;
     var svg = doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
     var text = doc.createElementNS('http://www.w3.org/2000/svg', 'text');
-    var width;
-    var height;
+    var rect;
 
     // assign proper styles and positioning to text elements
     text.textContent = content;
@@ -41,10 +41,11 @@ module.exports = function(elements, options) {
     svg.appendChild(text);
     elements[i].parentNode.replaceChild(svg, elements[i]);
 
-    width = text.offsetWidth || text.getComputedTextLength();
-    height = text.offsetHeight || 24;
+    rect = bounding ? text.getBoundingClientRect() : {};
+    rect.width = rect.width || text.offsetWidth || text.getComputedTextLength();
+    rect.height = rect.height || text.offsetHeight || 24;
 
-    svg.setAttribute('viewBox', '0 0 ' + width + ' ' + (height + paddingY));
+    svg.setAttribute('viewBox', '0 0 ' + Math.round(rect.width) + ' ' + (Math.round(rect.height) + paddingY));
 
   }
 


### PR DESCRIPTION
This fixes the following warning in Chrome, which looks like it could become a bigger issue soon:

> `SVGElement.offsetWidth` is deprecated and will be removed in
> [Chrome] M50, around April 2016. See
> https://www.chromestatus.com/features/5724912467574784 for more details.

`getBoundingClientRect()` is actually more precise, but I rounded the results and they come out exactly the same as before.

Tested in Safari on iOS 6.1, Safari 9.0.3, Chrome 48, and Firefox 43.
