### PR TITLE
Fix Edge strict error

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = function(elements, options) {
     svg.appendChild(text);
     elements[i].parentNode.replaceChild(svg, elements[i]);
 
-    rect = bounding ? text.getBoundingClientRect() : {};
+    rect = bounding ? Object.assign({}, text.getBoundingClientRect()) : {};
     rect.width = rect.width || text.offsetWidth || text.getComputedTextLength();
     rect.height = rect.height || text.offsetHeight || 24;
 


### PR DESCRIPTION
`Object.assign` is only available in edge or later.
if this is not a problem, otherwise you could use `extend ` as dependency or copy the variable in another way.